### PR TITLE
Migrate Paho MQTT client to Callback API version 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ haversine
 meshtastic
 requests
 pyyaml
-paho-mqtt
+paho-mqtt >= 2.0.0
 jwcrypto
 nostr


### PR DESCRIPTION
`paho-mqtt` recently updated their Callback API to [version 2](https://eclipse.dev/paho/files/paho.mqtt.python/html/changelog.html#v2-0-0-2024-02-10). Using their provided [migration guide](https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html), this pull request addresses some issues with newer installations of `meshtastic-bridge`.

- Resolves the deprecation warning on start-up
  ```
  /home/rgrizzell/meshtastic-bridge/main.py:129: DeprecationWarning: Callback API version 1 is deprecated, update to the latest version
    mqttc = mqtt.Client()
  ```
- Fixes an issue where the MQTT client fails to start when a `client_id` is specified in `config.yaml`.
  ```
  Traceback (most recent call last):
    File "/home/rgrizzell/meshtastic-bridge/main.py", line 127, in <module>
      mqttc = mqtt.Client(client_id)
    File "/home/rgrizzell/meshtastic-bridge/lib64/python3.10/site-packages/paho/mqtt/client.py", line 772, in __init__
      raise ValueError(
  ValueError: Unsupported callback API version: version 2.0 added a callback_api_version, see docs/migrations.rst for details
  ```
- Improves error handling around MQTT Auth and ACL issues.
  ```
  ERROR:meshtastic.bridge:Could not connect to MQTT local [Not authorized]
  ```